### PR TITLE
Set whitelisted at register

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,15 @@ Light weight tool for fetcher develpers to run real tests locally without Pomelo
 ## How to use
 The code that runs TestHarness is at `com/harness/main.go`. This code is called by `make harness` command
 
+### Register
+Init by passing the fetcher and whitelisted bool to Register method.
+`Register(builder thingfulx.FetcherBuilder, whitelisted bool)`
+If this fetcher whitelisted = true, it means that testHarness will ignore robots.txt completely.
+
+For example.
+`harness, err := testharness.Register(fetcherName.NewFetcher, false)`
+
+
 There are 3 main features, these functions can be used separately.
 
 ### RunAll

--- a/README.md
+++ b/README.md
@@ -33,10 +33,12 @@ The code that runs TestHarness is at `com/harness/main.go`. This code is called 
 
 ### Register
 Init by passing the fetcher and whitelisted bool to Register method.
-`Register(builder thingfulx.FetcherBuilder, whitelisted bool)`
-If this fetcher whitelisted = true, it means that testHarness will ignore robots.txt completely.
 
-For example.
+`Register(builder thingfulx.FetcherBuilder, whitelisted bool)`
+
+If this fetcher's whitelisted = `true`, it means that testHarness will ignore robots.txt completely. It is recommended to set this to `false` unless you are sure that we are allowed to ignore `robots.txt`
+
+For example: 
 `harness, err := testharness.Register(fetcherName.NewFetcher, false)`
 
 

--- a/testharness.go
+++ b/testharness.go
@@ -22,9 +22,11 @@ var (
 	EmptyThingsCount int = 0
 	URLsError        []error
 	FetchError       []string
+	WhiteListed      bool = false
 )
 
-func Register(builder thingfulx.FetcherBuilder) (*Harness, error) {
+func Register(builder thingfulx.FetcherBuilder, whitelisted bool) (*Harness, error) {
+	WhiteListed = whitelisted
 	fetcher, err := builder()
 	if err != nil {
 		return nil, err
@@ -370,6 +372,10 @@ func checkURLs(urls []string) (bool, error) {
 			allAllowed = false
 		}
 
+	}
+
+	if WhiteListed {
+		allAllowed = true
 	}
 
 	return allAllowed, nil


### PR DESCRIPTION
Many providers set `robots.txt` to block web crawler but in some cases we managed to get permission to fetch. So, upon `Register`, we can set if we want to ignore `robots.txt` or not. 