### PR TITLE
update to latest thingfulx version

### DIFF
--- a/glide.yaml
+++ b/glide.yaml
@@ -2,7 +2,7 @@ package: github.com/thingful/testharness
 import:
 - package: github.com/thingful/httpmock
 - package: github.com/thingful/thingfulx
-  version: 0.1.8
+  version: 0.1.9
 - package: github.com/stretchr/testify
 - package: golang.org/x/net/context
 - package: github.com/davecgh/go-spew

--- a/testharness.go
+++ b/testharness.go
@@ -54,7 +54,7 @@ func (h *Harness) RunAll(ctx context.Context, fetchInterval time.Duration, total
 	client := thingfulx.NewClient("thingful", timeout)
 	delay := time.Duration(10) * time.Second
 
-	URLs, err := h.fetcher.URLS(client, delay)
+	URLs, err := h.fetcher.URLS(ctx, client, delay)
 	if err != nil {
 		// panic(err)
 		fmt.Printf("## ERROR from URLs: %s\n", err.Error()) // we should log this


### PR DESCRIPTION
This PR updates thingfulx to version 0.1.9 and adds a `ctx` context argument to the fetcher URLS method so that it implements the updated thingfulx `Fetcher` interface.